### PR TITLE
Added trigger objects

### DIFF
--- a/Ntuplizer/interface/NtupleBranches.h
+++ b/Ntuplizer/interface/NtupleBranches.h
@@ -253,7 +253,13 @@ public:
     bool    isFired_HLT_PFHT900_v1				  ;
     bool    isFired_HLT_Ele95_CaloIdVT_GsfTrkIdT_v1               ;
     bool    isFired_HLT_Mu40_v1                                   ;
-	    
+	 
+ 	 std::vector<float>						triggerObject_pt				;
+  	 std::vector<float>						triggerObject_eta				;
+ 	 std::vector<float>						triggerObject_phi				;
+  	 std::vector<float>						triggerObject_mass			;
+	 std::vector< std::vector<float> >	triggerObject_filterIDs		; // as defined in http://cmslxr.fnal.gov/lxr/source/DataFormats/HLTReco/interface/TriggerTypeDefs.h
+	 std::vector< std::vector<int> >		triggerObject_firedTrigger	; // as defined in plugins/TriggersNtuplizer.cc
     /*-------------------------MET--------------------------------*/
     std::vector<float>                METraw_et              ;	 
     std::vector<float>                METraw_phi             ;

--- a/Ntuplizer/interface/Ntuplizer.h
+++ b/Ntuplizer/interface/Ntuplizer.h
@@ -12,8 +12,10 @@
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "SimDataFormats/JetMatching/interface/JetFlavourMatching.h"
 #include "SimDataFormats/JetMatching/interface/JetFlavour.h"
-
+#include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
+#include "DataFormats/PatCandidates/interface/PackedTriggerPrescales.h"
 #include "../interface/NtupleBranches.h"
+
 
 class NtupleBranches;
 class CandidateNtuplizer;
@@ -65,7 +67,9 @@ private:
   edm::EDGetTokenT<pat::METCollection> 	    				reclusteredmetToken_;
   edm::InputTag 											pfMETlabel;	     // input label for particle-flow MET
   
-  edm::EDGetTokenT<edm::TriggerResults>						triggerToken_;
+  edm::EDGetTokenT<edm::TriggerResults>						  triggerToken_;
+  edm::EDGetTokenT<pat::TriggerObjectStandAloneCollection> triggerObjects_;
+  edm::EDGetTokenT<pat::PackedTriggerPrescales>            triggerPrescales_;
   
 
 };

--- a/Ntuplizer/interface/TriggersNtuplizer.h
+++ b/Ntuplizer/interface/TriggersNtuplizer.h
@@ -2,18 +2,25 @@
 #define TriggersNtuplizer_H
 
 #include "../interface/CandidateNtuplizer.h"
+#include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
+#include "DataFormats/PatCandidates/interface/PackedTriggerPrescales.h"
 
 class TriggersNtuplizer : public CandidateNtuplizer {
 
 public:
-   TriggersNtuplizer( std::vector<edm::EDGetTokenT<edm::TriggerResults>> tokens, NtupleBranches* nBranches );
+   TriggersNtuplizer(edm::EDGetTokenT<edm::TriggerResults> tokens, edm::EDGetTokenT<pat::TriggerObjectStandAloneCollection> object, edm::EDGetTokenT<pat::PackedTriggerPrescales> prescale,  NtupleBranches* nBranches );
    ~TriggersNtuplizer( void );
    
   void fillBranches( edm::Event const & event, const edm::EventSetup& iSetup );
 
 private:
-   edm::EDGetTokenT<edm::TriggerResults	> HLTtriggersToken_;
-   edm::Handle< edm::TriggerResults 	> HLTtriggers_;
+   edm::EDGetTokenT<edm::TriggerResults> 							HLTtriggersToken_;
+   edm::EDGetTokenT<pat::TriggerObjectStandAloneCollection> triggerObjects_;
+   edm::EDGetTokenT<pat::PackedTriggerPrescales>            triggerPrescales_;
+	
+   edm::Handle< edm::TriggerResults> 								HLTtriggers_;
+	edm::Handle<pat::TriggerObjectStandAloneCollection> 		triggerObjects;
+	edm::Handle<pat::PackedTriggerPrescales> 						triggerPrescales;
       
 };
 

--- a/Ntuplizer/plugins/METsNtuplizer.cc
+++ b/Ntuplizer/plugins/METsNtuplizer.cc
@@ -202,6 +202,7 @@ void METsNtuplizer::fillBranches( edm::Event const & event, const edm::EventSetu
 	   		nBranches_->MET_sumEt.push_back(sumEtcorr);
 			nBranches_->MET_corrPx.push_back(TypeICorrMap_["corrEx"]);
 			nBranches_->MET_corrPy.push_back(TypeICorrMap_["corrEy"]);
+			
 		
 	   		//nBranches_->MET_T1Uncertainty.push_back(met.shiftedPt(pat::MET::NoShift, pat::MET::Type1));
 		} 

--- a/Ntuplizer/plugins/NtupleBranches.cc
+++ b/Ntuplizer/plugins/NtupleBranches.cc
@@ -217,6 +217,13 @@ void NtupleBranches::branch( void ){
   tree_->Branch("isFired_HLT_PFHT900_v1"				, &isFired_HLT_PFHT900_v1				  );
   tree_->Branch("isFired_HLT_Ele95_CaloIdVT_GsfTrkIdT_v1"		, &isFired_HLT_Ele95_CaloIdVT_GsfTrkIdT_v1		  );
   tree_->Branch("isFired_HLT_Mu40_v1"		 		        , &isFired_HLT_Mu40_v1					  );
+  
+  tree_->Branch("triggerObject_pt"				, &triggerObject_pt				);
+  tree_->Branch("triggerObject_eta"				, &triggerObject_eta				);
+  tree_->Branch("triggerObject_phi"				, &triggerObject_phi				);
+  tree_->Branch("triggerObject_mass"			, &triggerObject_mass			);
+  tree_->Branch("triggerObject_filterIDs"		, &triggerObject_filterIDs		);
+  tree_->Branch("triggerObject_firedTrigger"	, &triggerObject_firedTrigger	);
 
   /*-------------------------MET--------------------------------*/
   tree_->Branch("METraw_et"		        , &METraw_et	     );
@@ -460,5 +467,12 @@ void NtupleBranches::reset( void ){
   nPuVtxTrue             .clear();
   nPuVtx       		 .clear();
   bX	     		 .clear();
+  
+  triggerObject_pt.clear();
+  triggerObject_eta.clear();
+  triggerObject_phi.clear();
+  triggerObject_mass.clear();
+  triggerObject_filterIDs.clear();
+  triggerObject_firedTrigger.clear();
 
 } 

--- a/Ntuplizer/plugins/Ntuplizer.cc
+++ b/Ntuplizer/plugins/Ntuplizer.cc
@@ -10,6 +10,8 @@
 #include "../interface/GenParticlesNtuplizer.h"
 #include "../interface/TriggersNtuplizer.h"
 #include "../interface/VerticesNtuplizer.h"
+#include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
+#include "DataFormats/PatCandidates/interface/PackedTriggerPrescales.h"
 
 // #include "DataFormats/METReco/interface/PFMET.h"
 
@@ -40,7 +42,9 @@ Ntuplizer::Ntuplizer(const edm::ParameterSet& iConfig):
 	metToken_			(consumes<pat::METCollection>					(iConfig.getParameter<edm::InputTag>("mets"))),
 	reclusteredmetToken_(consumes<pat::METCollection>					(iConfig.getParameter<edm::InputTag>("reclusteredmets"))),
 	pfMETlabel          (iConfig.getParameter<edm::InputTag>("pfmets")),
-	triggerToken_		(consumes<edm::TriggerResults>					(iConfig.getParameter<edm::InputTag>("HLT")))
+	triggerToken_		(consumes<edm::TriggerResults>							(iConfig.getParameter<edm::InputTag>("HLT"))),
+	triggerObjects_	(consumes<pat::TriggerObjectStandAloneCollection>	(iConfig.getParameter<edm::InputTag>("triggerobjects"))),
+	triggerPrescales_	(consumes<pat::PackedTriggerPrescales>					(iConfig.getParameter<edm::InputTag>("triggerprescales")))
 	
 	
 
@@ -93,19 +97,19 @@ Ntuplizer::Ntuplizer(const edm::ParameterSet& iConfig):
   vtxTokens.push_back( vtxToken_  );
   
   /*=======================================================================================*/
-  std::vector<edm::EDGetTokenT<edm::TriggerResults>> triggerTokens;
-  triggerTokens.push_back( triggerToken_ );
+  // std::vector<edm::EDGetTokenT<edm::TriggerResults>> triggerTokens;
+ //  triggerTokens.push_back( triggerToken_ );
   
   /*=======================================================================================*/
   
 
-  nTuplizers_["jets"]  	   = new JetsNtuplizer	    ( jetTokens		, jecAK4Labels	, jecAK8Labels, flavourToken_	, rhoToken_ , vtxToken_ , nBranches_ );
-  nTuplizers_["genJets"]   = new GenJetsNtuplizer	    ( genJetToken_ , nBranches_ );
-  nTuplizers_["muons"] 	   = new MuonsNtuplizer     ( muonToken_	, vtxToken_		, rhoToken_						, nBranches_ );
-  nTuplizers_["electrons"] = new ElectronsNtuplizer ( electronToken_, vtxToken_     , rhoToken_						, nBranches_ );
-  nTuplizers_["MET"]       = new METsNtuplizer      ( metTokens		, pfMETlabel	, jetToken_		, muonToken_  , jecAK4Labels, corrFormulas, rhoToken_ , vtxToken_ , nBranches_ );
-  nTuplizers_["vertices"]  = new VerticesNtuplizer  ( vtxTokens														, nBranches_ );
-  nTuplizers_["triggers"]  = new TriggersNtuplizer  ( triggerTokens     											, nBranches_ );
+  nTuplizers_["jets"]  	   = new JetsNtuplizer	    ( jetTokens		, jecAK4Labels		, jecAK8Labels	, flavourToken_	, rhoToken_ , vtxToken_ , nBranches_ );
+  nTuplizers_["genJets"]   = new GenJetsNtuplizer	 ( genJetToken_ 							, nBranches_ );
+  nTuplizers_["muons"] 	   = new MuonsNtuplizer     ( muonToken_		, vtxToken_			, rhoToken_		, nBranches_ );
+  nTuplizers_["electrons"] = new ElectronsNtuplizer ( electronToken_	, vtxToken_     	, rhoToken_		, nBranches_ );
+  nTuplizers_["MET"]       = new METsNtuplizer      ( metTokens		, pfMETlabel		, jetToken_		, muonToken_  , jecAK4Labels, corrFormulas, rhoToken_ , vtxToken_ , nBranches_ );
+  nTuplizers_["vertices"]  = new VerticesNtuplizer  ( vtxTokens													, nBranches_ );
+  nTuplizers_["triggers"]  = new TriggersNtuplizer  ( triggerToken_  , triggerObjects_	, triggerPrescales_	, nBranches_ );
 
 
   /*=======================================================================================*/    

--- a/Ntuplizer/plugins/TriggersNtuplizer.cc
+++ b/Ntuplizer/plugins/TriggersNtuplizer.cc
@@ -1,11 +1,15 @@
 #include "../interface/TriggersNtuplizer.h"
 #include "FWCore/Common/interface/TriggerNames.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
+#include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
+#include "DataFormats/PatCandidates/interface/PackedTriggerPrescales.h"
 
 //===================================================================================================================        
-TriggersNtuplizer::TriggersNtuplizer( std::vector<edm::EDGetTokenT<edm::TriggerResults>> tokens, NtupleBranches* nBranches )
-   : CandidateNtuplizer( nBranches )
-   , HLTtriggersToken_( tokens[0] )
+TriggersNtuplizer::TriggersNtuplizer(edm::EDGetTokenT<edm::TriggerResults> tokens, edm::EDGetTokenT<pat::TriggerObjectStandAloneCollection> object, edm::EDGetTokenT<pat::PackedTriggerPrescales> prescale,  NtupleBranches* nBranches )
+   : CandidateNtuplizer	( nBranches )
+   , HLTtriggersToken_	( tokens )
+	, triggerObjects_		( object )	
+	, triggerPrescales_	( prescale )		
 {
    
 }
@@ -19,9 +23,13 @@ TriggersNtuplizer::~TriggersNtuplizer( void )
 //===================================================================================================================
 void TriggersNtuplizer::fillBranches( edm::Event const & event, const edm::EventSetup& iSetup ){
 	
-	event.getByToken(HLTtriggersToken_, HLTtriggers_);
+	event.getByToken(HLTtriggersToken_, HLTtriggers_);	
+	event.getByToken(triggerObjects_, triggerObjects);
+	event.getByToken(triggerPrescales_, triggerPrescales);
+	
 	const edm::TriggerNames& trigNames = event.triggerNames(*HLTtriggers_);
-
+	
+	
 	// for (unsigned int i = 0, n = HLTtriggers_->size(); i < n; ++i) {
 // 	  std::cout << "Trigger " << trigNames.triggerName(i) << std::endl;//<< ": " << (HLTtriggers_->accept(i) ? "PASS" : "fail (or not run)") << std::endl;
 // 	}
@@ -58,6 +66,46 @@ void TriggersNtuplizer::fillBranches( edm::Event const & event, const edm::Event
 	if( TrggIndex_HLT_Ele95_CaloIdVT_GsfTrkIdT_v1 < HLTtriggers_->size() ) nBranches_->isFired_HLT_Ele95_CaloIdVT_GsfTrkIdT_v1 = HLTtriggers_->accept(TrggIndex_HLT_Ele95_CaloIdVT_GsfTrkIdT_v1);
 	if( TrggIndex_HLT_Mu40_v1 < HLTtriggers_->size() ) nBranches_->isFired_HLT_Mu40_v1 = HLTtriggers_->accept(TrggIndex_HLT_Mu40_v1);
 	
+	////////////////// Trigger objects ///////////////////////////////////	
+	
+   std::vector<float> vfilterIDs     ;
+   vfilterIDs.clear();
+   std::vector<int> vfiredTrigger     ;
+   vfiredTrigger.clear();
+	
+	for (pat::TriggerObjectStandAlone obj : *triggerObjects) { 
+		obj.unpackPathNames(trigNames);
+		
+		std::vector<std::string> pathNamesAll  = obj.pathNames(false);
+		std::vector<std::string> pathNamesLast = obj.pathNames(true);
+		
+		for (unsigned h = 0, n = pathNamesLast.size(); h < n; ++h) {
+			bool isBoth = obj.hasPathName( pathNamesLast[h], true , true );
+         bool isL3   = obj.hasPathName( pathNamesLast[h], false, true );
+			
+			if( isBoth || isL3 ){
+				nBranches_->triggerObject_pt   	    .push_back(obj.pt());
+			   nBranches_->triggerObject_eta    	    .push_back(obj.eta());
+			   nBranches_->triggerObject_phi    	    .push_back(obj.phi());
+			   nBranches_->triggerObject_mass        .push_back(obj.mass());
+				
+				for (unsigned h = 0; h < obj.filterIds().size(); ++h) vfilterIDs.push_back( obj.filterIds()[h]); // as defined in http://cmslxr.fnal.gov/lxr/source/DataFormats/HLTReco/interface/TriggerTypeDefs.h
+				
+				if( pathNamesLast[h] == "HLT_AK8PFJet360TrimMod_Mass30_v1") 					vfiredTrigger			 .push_back( 0 );
+				if( pathNamesLast[h] == "HT_AK8PFHT700_TrimR0p1PT0p03Mass50_v1") 				vfiredTrigger   	    .push_back( 1 );
+			   if( pathNamesLast[h] == "HLT_AK8DiPFJet280_200_TrimMass30_BTagCSV0p3_v1")	vfiredTrigger   	    .push_back( 2 );
+			   if( pathNamesLast[h] == "HLT_PFHT650_WideJetMJJ950DEtaJJ1p5_v1") 				vfiredTrigger   	    .push_back( 3 );
+			   if( pathNamesLast[h] == "HLT_PFHT650_WideJetMJJ950DEtaJJ1p5_v1") 				vfiredTrigger   	    .push_back( 4 );
+			   if( pathNamesLast[h] == "HLT_PFHT650_WideJetMJJ900DEtaJJ1p5_v1")  			vfiredTrigger   	    .push_back( 5 );
+			   if( pathNamesLast[h] == "HLT_PFHT900_v1")  											vfiredTrigger   	    .push_back( 6 );
+			   if( pathNamesLast[h] == "HLT_Ele95_CaloIdVT_GsfTrkIdT_v1")  					vfiredTrigger   	    .push_back( 7 );
+			   if( pathNamesLast[h] == "HLT_Mu40_v1") 												vfiredTrigger   	    .push_back( 8 );
+			   // else 																								vfiredTrigger   	    .push_back( -99 );
+			}
+		}
+		nBranches_->triggerObject_filterIDs		.push_back(vfilterIDs);
+		nBranches_->triggerObject_firedTrigger	.push_back(vfiredTrigger);
+	}
 }
 // ###### Available triggers #######
 // Trigger generation_step

--- a/Ntuplizer/plugins/TriggersNtuplizer.cc
+++ b/Ntuplizer/plugins/TriggersNtuplizer.cc
@@ -95,11 +95,10 @@ void TriggersNtuplizer::fillBranches( edm::Event const & event, const edm::Event
 				if( pathNamesLast[h] == "HT_AK8PFHT700_TrimR0p1PT0p03Mass50_v1") 				vfiredTrigger   	    .push_back( 1 );
 			   if( pathNamesLast[h] == "HLT_AK8DiPFJet280_200_TrimMass30_BTagCSV0p3_v1")	vfiredTrigger   	    .push_back( 2 );
 			   if( pathNamesLast[h] == "HLT_PFHT650_WideJetMJJ950DEtaJJ1p5_v1") 				vfiredTrigger   	    .push_back( 3 );
-			   if( pathNamesLast[h] == "HLT_PFHT650_WideJetMJJ950DEtaJJ1p5_v1") 				vfiredTrigger   	    .push_back( 4 );
-			   if( pathNamesLast[h] == "HLT_PFHT650_WideJetMJJ900DEtaJJ1p5_v1")  			vfiredTrigger   	    .push_back( 5 );
-			   if( pathNamesLast[h] == "HLT_PFHT900_v1")  											vfiredTrigger   	    .push_back( 6 );
-			   if( pathNamesLast[h] == "HLT_Ele95_CaloIdVT_GsfTrkIdT_v1")  					vfiredTrigger   	    .push_back( 7 );
-			   if( pathNamesLast[h] == "HLT_Mu40_v1") 												vfiredTrigger   	    .push_back( 8 );
+			   if( pathNamesLast[h] == "HLT_PFHT650_WideJetMJJ900DEtaJJ1p5_v1")  			vfiredTrigger   	    .push_back( 4 );
+			   if( pathNamesLast[h] == "HLT_PFHT900_v1")  											vfiredTrigger   	    .push_back( 5 );
+			   if( pathNamesLast[h] == "HLT_Ele95_CaloIdVT_GsfTrkIdT_v1")  					vfiredTrigger   	    .push_back( 6 );
+			   if( pathNamesLast[h] == "HLT_Mu40_v1") 												vfiredTrigger   	    .push_back( 7 );
 			   // else 																								vfiredTrigger   	    .push_back( -99 );
 			}
 		}


### PR DESCRIPTION
Pt, eta, phi, mass, ID and which rigger is fired is stored for for triggerobjects that caused one of the triggers we are currently looking at (2 lepton triggers, 6 jet triggers) to fire. Filter IDs as listed in http://cmslxr.fnal.gov/lxr/source/DataFormats/HLTReco/interface/TriggerTypeDefs.h . Triggers fired are stored in vector of ints (0-8) for each trigger object as:
0 = HLT_AK8PFJet360TrimMod_Mass30_v1
1 = HLT_AK8PFHT700_TrimR0p1PT0p03Mass50_v1
2 = HLT_AK8DiPFJet280_200_TrimMass30_BTagCSV0p3_v1
3 = HLT_PFHT650_WideJetMJJ950DEtaJJ1p5_v1
4 = HLT_PFHT650_WideJetMJJ900DEtaJJ1p5_v1
5 = HLT_PFHT900_v1
6 = HLT_Ele95_CaloIdVT_GsfTrkIdT_v1
7 = HLT_Mu40_v1