### PR TITLE
Disable PUPPI reclustering if running on MiniAODv2

### DIFF
--- a/Ntuplizer/config_data.py
+++ b/Ntuplizer/config_data.py
@@ -50,7 +50,7 @@ process.source = cms.Source("PoolSource",
 hltFiltersProcessName = 'RECO'
 if config["RUNONMC"] or config["JSONFILE"].find('reMiniAOD') != -1:
   hltFiltersProcessName = 'PAT'
-reclusterPuppi=(not 'MiniAODv2' in options.inputFiles[0])
+reclusterPuppi=False
 if reclusterPuppi:
   print "RECLUSTERING PUPPI (since not running of Spring16MiniAODv2)"
 

--- a/Ntuplizer/interface/JetsNtuplizer.h
+++ b/Ntuplizer/interface/JetsNtuplizer.h
@@ -65,7 +65,7 @@ public:
   bool doCorrOnTheFly_;
   bool doAK4Jets_;
   bool doAK8Jets_;
-  bool doPruning_;
+  bool doPuppiRecluster_;
   bool runOnMC_;
 
 };

--- a/Ntuplizer/interface/NtupleBranches.h
+++ b/Ntuplizer/interface/NtupleBranches.h
@@ -470,6 +470,21 @@ public:
   std::vector< std::vector<int  > > jetAK8_subjet_softdrop_hadronFlavour;
   std::vector< std::vector<float> > jetAK8_subjet_softdrop_csv    ;
 
+  /** puppi_softdrop AK8 subjets */
+  std::vector<int>                  jetAK8_subjet_puppi_softdrop_N      ;
+  std::vector< std::vector<float> > jetAK8_subjet_puppi_softdrop_pt     ;
+  std::vector< std::vector<float> > jetAK8_subjet_puppi_softdrop_eta    ;
+  std::vector< std::vector<float> > jetAK8_subjet_puppi_softdrop_mass   ;
+  std::vector< std::vector<float> > jetAK8_subjet_puppi_softdrop_phi    ;
+  std::vector< std::vector<float> > jetAK8_subjet_puppi_softdrop_e      ;
+  std::vector< std::vector<int  > > jetAK8_subjet_puppi_softdrop_charge ;
+  std::vector< std::vector<int  > > jetAK8_subjet_puppi_softdrop_genParton_pdgID ;
+  std::vector< std::vector<int  > > jetAK8_subjet_puppi_softdrop_nbHadrons ;
+  std::vector< std::vector<int  > > jetAK8_subjet_puppi_softdrop_ncHadrons ;
+  std::vector< std::vector<int  > > jetAK8_subjet_puppi_softdrop_partonFlavour;
+  std::vector< std::vector<int  > > jetAK8_subjet_puppi_softdrop_hadronFlavour;
+  std::vector< std::vector<float> > jetAK8_subjet_puppi_softdrop_csv    ;
+
   /** puppi and ATLAS */    
   std::vector<float>	      jetAK10_trimmed_mass           ;
   std::vector<float>	      jetAK10_trimmed_massCorr       ;

--- a/Ntuplizer/plugins/JetsNtuplizer.cc
+++ b/Ntuplizer/plugins/JetsNtuplizer.cc
@@ -557,8 +557,8 @@ void JetsNtuplizer::fillBranches( edm::Event const & event, const edm::EventSetu
         }
 	else{
 	      
-           nBranches_->jetAK8_pruned_massCorr.push_back(-1);
-           nBranches_->jetAK8_pruned_jec.push_back(-1);
+           nBranches_->jetAK8_pruned_massCorr.push_back(-99);
+           nBranches_->jetAK8_pruned_jec.push_back(-99);
 	   
 	}
 
@@ -725,8 +725,8 @@ void JetsNtuplizer::fillBranches( edm::Event const & event, const edm::EventSetu
         }
 	else{
 	      
-           nBranches_->jetAK8_softdrop_massCorr.push_back(-1);
-           nBranches_->jetAK8_softdrop_jec.push_back(-1);
+           nBranches_->jetAK8_softdrop_massCorr.push_back(-99);
+           nBranches_->jetAK8_softdrop_jec.push_back(-99);
 	   
 	}
 
@@ -845,15 +845,15 @@ void JetsNtuplizer::fillBranches( edm::Event const & event, const edm::EventSetu
         nBranches_->jetAK8_puppi_e      	    .push_back(corr*uncorrJet.energy());
 
         } else {
-        nBranches_->jetAK8_puppi_tau1	 .push_back(-1);	 
-        nBranches_->jetAK8_puppi_tau2	 .push_back(-1);
-        nBranches_->jetAK8_puppi_tau3	 .push_back(-1); 
-        //nBranches_->jetAK8_puppi_pruned_mass.push_back(-1);
-        nBranches_->jetAK8_puppi_softdrop_mass.push_back(-1);
-        //nBranches_->jetAK8_puppi_pruned_massCorr.push_back(-1);
-        //nBranches_->jetAK8_puppi_pruned_jec.push_back(-1);
-        nBranches_->jetAK8_puppi_softdrop_massCorr.push_back(-1);
-        nBranches_->jetAK8_puppi_softdrop_jec.push_back(-1);
+        nBranches_->jetAK8_puppi_tau1	 .push_back(-99);	 
+        nBranches_->jetAK8_puppi_tau2	 .push_back(-99);
+        nBranches_->jetAK8_puppi_tau3	 .push_back(-99); 
+        //nBranches_->jetAK8_puppi_pruned_mass.push_back(-99);
+        nBranches_->jetAK8_puppi_softdrop_mass.push_back(-99);
+        //nBranches_->jetAK8_puppi_pruned_massCorr.push_back(-99);
+        //nBranches_->jetAK8_puppi_pruned_jec.push_back(-99);
+        nBranches_->jetAK8_puppi_softdrop_massCorr.push_back(-99);
+        nBranches_->jetAK8_puppi_softdrop_jec.push_back(-99);
         nBranches_->jetAK8_puppi_pt     	    .push_back(-99);                   
         nBranches_->jetAK8_puppi_eta    	    .push_back(-99);
         nBranches_->jetAK8_puppi_mass   	    .push_back(-99);
@@ -903,8 +903,8 @@ void JetsNtuplizer::fillBranches( edm::Event const & event, const edm::EventSetu
         }
 	else{
 	      
-           nBranches_->jetAK8_puppi_softdrop_massCorr.push_back(-1);
-           nBranches_->jetAK8_puppi_softdrop_jec.push_back(-1);
+           nBranches_->jetAK8_puppi_softdrop_massCorr.push_back(-99);
+           nBranches_->jetAK8_puppi_softdrop_jec.push_back(-99);
 	   
 	}
 

--- a/Ntuplizer/plugins/JetsNtuplizer.cc
+++ b/Ntuplizer/plugins/JetsNtuplizer.cc
@@ -17,6 +17,7 @@ JetsNtuplizer::JetsNtuplizer( std::vector<edm::EDGetTokenT<pat::JetCollection>> 
   , verticeToken_     	    ( verticeToken )
   , doAK4Jets_ (runFlags["doAK4Jets"])
   , doAK8Jets_ (runFlags["doAK8Jets"])
+  , doPuppiRecluster_ (runFlags["doPuppiRecluster"])
   , runOnMC_   (runFlags["runOnMC"])
    //, flavourToken_			( flavourToken 	) //For subjet flavour matching!! Not done yet.
     
@@ -165,7 +166,8 @@ void JetsNtuplizer::fillBranches( edm::Event const & event, const edm::EventSetu
   bool doPruning  = event.getByToken(prunedjetInputToken_, prunedjets_ );
   bool doSoftDrop = event.getByToken(softdropjetInputToken_, softdropjets_ );
   bool doTrimming  = event.getByToken(trimmedjetInputToken_, trimmedjets_ );
-  bool doPuppi  = event.getByToken(puppijetInputToken_, puppijets_ );
+  bool doPuppi  = doPuppiRecluster_;
+  if (doPuppi) doPuppi=event.getByToken(puppijetInputToken_, puppijets_ );
   bool isMC = runOnMC_;
 
   /****************************************************************/
@@ -300,6 +302,24 @@ void JetsNtuplizer::fillBranches( edm::Event const & event, const edm::EventSetu
     std::vector<float> vSoftDropSubjettche   ;
     std::vector<float> vSoftDropSubjetjp     ;
     std::vector<float> vSoftDropSubjetjbp    ;
+     
+    std::vector<float> vPuppiSoftDropSubjetpt     ;
+    std::vector<float> vPuppiSoftDropSubjeteta    ;
+    std::vector<float> vPuppiSoftDropSubjetmass   ;
+    std::vector<float> vPuppiSoftDropSubjetphi    ;
+    std::vector<float> vPuppiSoftDropSubjete      ;
+    std::vector<int  > vPuppiSoftDropSubjetcharge ;
+    std::vector<int  > vPuppiSoftDropSubjetGenPartonPdgId;
+    std::vector<int  > vPuppiSoftDropSubjetnbHadrons;
+    std::vector<int  > vPuppiSoftDropSubjetncHadrons;
+    std::vector<int  > vPuppiSoftDropSubjetPartonFlavour;
+    std::vector<int  > vPuppiSoftDropSubjetHadronFlavour;
+    std::vector<float> vPuppiSoftDropSubjetssv    ;
+    std::vector<float> vPuppiSoftDropSubjetcsv    ;
+    std::vector<float> vPuppiSoftDropSubjettchp   ;
+    std::vector<float> vPuppiSoftDropSubjettche   ;
+    std::vector<float> vPuppiSoftDropSubjetjp     ;
+    std::vector<float> vPuppiSoftDropSubjetjbp    ;
      
     for (const pat::Jet &fj : *fatjets_) {
 	  
@@ -537,8 +557,8 @@ void JetsNtuplizer::fillBranches( edm::Event const & event, const edm::EventSetu
         }
 	else{
 	      
-           nBranches_->jetAK8_pruned_massCorr.push_back(-99);
-           nBranches_->jetAK8_pruned_jec.push_back(-99);
+           nBranches_->jetAK8_pruned_massCorr.push_back(-1);
+           nBranches_->jetAK8_pruned_jec.push_back(-1);
 	   
 	}
 
@@ -705,8 +725,8 @@ void JetsNtuplizer::fillBranches( edm::Event const & event, const edm::EventSetu
         }
 	else{
 	      
-           nBranches_->jetAK8_softdrop_massCorr.push_back(-99);
-           nBranches_->jetAK8_softdrop_jec.push_back(-99);
+           nBranches_->jetAK8_softdrop_massCorr.push_back(-1);
+           nBranches_->jetAK8_softdrop_jec.push_back(-1);
 	   
 	}
 
@@ -825,15 +845,15 @@ void JetsNtuplizer::fillBranches( edm::Event const & event, const edm::EventSetu
         nBranches_->jetAK8_puppi_e      	    .push_back(corr*uncorrJet.energy());
 
         } else {
-        nBranches_->jetAK8_puppi_tau1	 .push_back(-99);	 
-        nBranches_->jetAK8_puppi_tau2	 .push_back(-99);
-        nBranches_->jetAK8_puppi_tau3	 .push_back(-99); 
-        //nBranches_->jetAK8_puppi_pruned_mass.push_back(-99);
-        nBranches_->jetAK8_puppi_softdrop_mass.push_back(-99);
-        //nBranches_->jetAK8_puppi_pruned_massCorr.push_back(-99);
-        //nBranches_->jetAK8_puppi_pruned_jec.push_back(-99);
-        nBranches_->jetAK8_puppi_softdrop_massCorr.push_back(-99);
-        nBranches_->jetAK8_puppi_softdrop_jec.push_back(-99);
+        nBranches_->jetAK8_puppi_tau1	 .push_back(-1);	 
+        nBranches_->jetAK8_puppi_tau2	 .push_back(-1);
+        nBranches_->jetAK8_puppi_tau3	 .push_back(-1); 
+        //nBranches_->jetAK8_puppi_pruned_mass.push_back(-1);
+        nBranches_->jetAK8_puppi_softdrop_mass.push_back(-1);
+        //nBranches_->jetAK8_puppi_pruned_massCorr.push_back(-1);
+        //nBranches_->jetAK8_puppi_pruned_jec.push_back(-1);
+        nBranches_->jetAK8_puppi_softdrop_massCorr.push_back(-1);
+        nBranches_->jetAK8_puppi_softdrop_jec.push_back(-1);
         nBranches_->jetAK8_puppi_pt     	    .push_back(-99);                   
         nBranches_->jetAK8_puppi_eta    	    .push_back(-99);
         nBranches_->jetAK8_puppi_mass   	    .push_back(-99);
@@ -841,6 +861,101 @@ void JetsNtuplizer::fillBranches( edm::Event const & event, const edm::EventSetu
         nBranches_->jetAK8_puppi_e      	    .push_back(-99);
 	}
 
+      } //doPuppi
+      else{
+        double puppi_pt  = fj.userFloat("ak8PFJetsPuppiValueMap:pt");
+        double puppi_mass  = fj.userFloat("ak8PFJetsPuppiValueMap:mass");
+        double puppi_eta  = fj.userFloat("ak8PFJetsPuppiValueMap:eta");
+        double puppi_phi  = fj.userFloat("ak8PFJetsPuppiValueMap:phi");
+        nBranches_->jetAK8_puppi_pt     	    .push_back(puppi_pt);                   
+        nBranches_->jetAK8_puppi_eta    	    .push_back(puppi_eta);
+        nBranches_->jetAK8_puppi_mass   	    .push_back(puppi_mass);
+        nBranches_->jetAK8_puppi_phi    	    .push_back(puppi_phi);
+        TLorentzVector puppi;
+        puppi.SetPtEtaPhiM(puppi_pt,puppi_eta,puppi_phi,puppi_mass);
+        nBranches_->jetAK8_puppi_e      	    .push_back(puppi.E());
+        nBranches_->jetAK8_puppi_tau1	 .push_back(fj.userFloat("ak8PFJetsPuppiValueMap:NjettinessAK8PuppiTau1"));	 
+        nBranches_->jetAK8_puppi_tau2	 .push_back(fj.userFloat("ak8PFJetsPuppiValueMap:NjettinessAK8PuppiTau2"));
+        nBranches_->jetAK8_puppi_tau3	 .push_back(fj.userFloat("ak8PFJetsPuppiValueMap:NjettinessAK8PuppiTau3")); 
+
+        TLorentzVector puppi_softdrop, puppi_softdrop_subjet;
+        auto const & sdSubjetsPuppi = fj.subjets("SoftDropPuppi");
+        for ( auto const & it : sdSubjetsPuppi ) {
+          puppi_softdrop_subjet.SetPtEtaPhiM(it->correctedP4(0).pt(),it->correctedP4(0).eta(),it->correctedP4(0).phi(),it->correctedP4(0).mass());
+          puppi_softdrop+=puppi_softdrop_subjet;
+        }
+
+        nBranches_->jetAK8_puppi_softdrop_mass.push_back(puppi_softdrop.M());
+
+        double puppi_softdropcorr = 1;
+        if( doCorrOnTheFly_ ){
+           // Using puppi corrections for softdrop puppi jets. Approximation!
+           jecAK8Puppi_->setJetEta( puppi_softdrop.Eta()    );
+           jecAK8Puppi_->setJetPt ( puppi_softdrop.Pt()     );
+           jecAK8Puppi_->setJetE  ( puppi_softdrop.E() );
+           jecAK8Puppi_->setJetA  ( fj.jetArea()             );
+           jecAK8Puppi_->setRho   ( nBranches_->rho          );
+           jecAK8Puppi_->setNPV   ( vertices_->size()        );
+           puppi_softdropcorr = jecAK8Puppi_->getCorrection();
+           nBranches_->jetAK8_puppi_softdrop_massCorr.push_back(puppi_softdropcorr*puppi_softdrop.M());
+           nBranches_->jetAK8_puppi_softdrop_jec.push_back(puppi_softdropcorr);
+	          
+        }
+	else{
+	      
+           nBranches_->jetAK8_puppi_softdrop_massCorr.push_back(-1);
+           nBranches_->jetAK8_puppi_softdrop_jec.push_back(-1);
+	   
+	}
+
+        vPuppiSoftDropSubjetpt.clear();
+        vPuppiSoftDropSubjeteta.clear();
+        vPuppiSoftDropSubjetmass.clear();
+        vPuppiSoftDropSubjetphi.clear();
+        vPuppiSoftDropSubjete.clear();
+        vPuppiSoftDropSubjetcharge.clear();
+        vPuppiSoftDropSubjetPartonFlavour.clear();
+        vPuppiSoftDropSubjetHadronFlavour.clear();
+        vPuppiSoftDropSubjetcsv.clear();
+      
+        nsubjets = 0;
+      
+        const std::vector<edm::Ptr<pat::Jet> > &wSubjets = fj.subjets("SoftDropPuppi");
+    
+      	for ( const pat::Jet & puppi_softdropsubjet : wSubjets ) {
+	
+           if( puppi_softdropsubjet.pt() < 0.01 ) continue;
+         
+           nsubjets++;
+
+           vPuppiSoftDropSubjetpt.push_back(puppi_softdropsubjet.pt());
+           vPuppiSoftDropSubjeteta.push_back(puppi_softdropsubjet.eta());
+           vPuppiSoftDropSubjetmass.push_back(puppi_softdropsubjet.mass());
+           vPuppiSoftDropSubjetphi.push_back(puppi_softdropsubjet.phi());
+           vPuppiSoftDropSubjete.push_back(puppi_softdropsubjet.energy());
+           vPuppiSoftDropSubjetPartonFlavour.push_back(abs(puppi_softdropsubjet.partonFlavour()));
+           vPuppiSoftDropSubjetHadronFlavour.push_back(abs(puppi_softdropsubjet.hadronFlavour()));
+           vPuppiSoftDropSubjetcharge.push_back(puppi_softdropsubjet.charge());
+           vPuppiSoftDropSubjetcsv.push_back(puppi_softdropsubjet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags") );
+         
+         } 
+
+        nBranches_->jetAK8_subjet_puppi_softdrop_N.push_back(nsubjets);
+        nBranches_->jetAK8_subjet_puppi_softdrop_pt.push_back(vPuppiSoftDropSubjetpt);
+        nBranches_->jetAK8_subjet_puppi_softdrop_eta.push_back(vPuppiSoftDropSubjeteta);
+        nBranches_->jetAK8_subjet_puppi_softdrop_mass.push_back(vPuppiSoftDropSubjetmass);
+        nBranches_->jetAK8_subjet_puppi_softdrop_phi.push_back(vPuppiSoftDropSubjetphi);
+        nBranches_->jetAK8_subjet_puppi_softdrop_e.push_back(vPuppiSoftDropSubjete);
+        nBranches_->jetAK8_subjet_puppi_softdrop_charge.push_back(vPuppiSoftDropSubjetcharge);
+        nBranches_->jetAK8_subjet_puppi_softdrop_csv.push_back(vPuppiSoftDropSubjetcsv);
+
+        if(isMC){
+	
+          nBranches_->jetAK8_subjet_puppi_softdrop_partonFlavour.push_back(vPuppiSoftDropSubjetPartonFlavour);
+          nBranches_->jetAK8_subjet_puppi_softdrop_hadronFlavour.push_back(vPuppiSoftDropSubjetHadronFlavour);
+	  
+        }
+			
       }
 
     } // ak8 jet loop

--- a/Ntuplizer/plugins/NtupleBranches.cc
+++ b/Ntuplizer/plugins/NtupleBranches.cc
@@ -399,23 +399,6 @@ void NtupleBranches::branch( std::map< std::string, bool >& runFlags ){
      tree_->Branch( "jetAK10_ecf3"	     , &jetAK10_ecf3	    	 );
     }
 
-    if (runFlags["doPuppi"]) {
-      /*----------------------PUPPI ---------------------------*/   
-     tree_->Branch( "jetAK8_puppi_pt"        , &jetAK8_puppi_pt    	);
-     tree_->Branch( "jetAK8_puppi_eta"       , &jetAK8_puppi_eta	);
-     tree_->Branch( "jetAK8_puppi_mass"      , &jetAK8_puppi_mass	 );
-     tree_->Branch( "jetAK8_puppi_phi"       , &jetAK8_puppi_phi	);
-     tree_->Branch( "jetAK8_puppi_e"	     , &jetAK8_puppi_e	);
-     tree_->Branch( "jetAK8_puppi_pruned_mass"      , &jetAK8_puppi_pruned_mass       );
-     tree_->Branch( "jetAK8_puppi_pruned_massCorr"  , &jetAK8_puppi_pruned_massCorr   );
-     tree_->Branch( "jetAK8_puppi_pruned_jec"	    , &jetAK8_puppi_pruned_jec        );
-     tree_->Branch( "jetAK8_puppi_softdrop_mass"    , &jetAK8_puppi_softdrop_mass     ); 
-     tree_->Branch( "jetAK8_puppi_softdrop_massCorr", &jetAK8_puppi_softdrop_massCorr );
-     tree_->Branch( "jetAK8_puppi_softdrop_jec"     , &jetAK8_puppi_softdrop_jec      );
-     tree_->Branch( "jetAK8_puppi_tau1"	            , &jetAK8_puppi_tau1	      );
-     tree_->Branch( "jetAK8_puppi_tau2"	            , &jetAK8_puppi_tau2      	      );
-     tree_->Branch( "jetAK8_puppi_tau3"	            , &jetAK8_puppi_tau3	      );
-    }
       // /*----------------------Softdrop AK8 subjets---------------------------*/
       tree_->Branch( "jetAK8_subjet_softdrop_N"            , &jetAK8_subjet_softdrop_N  	   );
       tree_->Branch( "jetAK8_subjet_softdrop_pt"           , &jetAK8_subjet_softdrop_pt      	   );
@@ -432,6 +415,41 @@ void NtupleBranches::branch( std::map< std::string, bool >& runFlags ){
         tree_->Branch( "jetAK8_subjet_softdrop_hadronFlavour", &jetAK8_subjet_softdrop_hadronFlavour );
       }
       tree_->Branch( "jetAK8_subjet_softdrop_csv"          , &jetAK8_subjet_softdrop_csv           );
+      
+    if (runFlags["doPuppi"]) {
+      /*----------------------PUPPI ---------------------------*/   
+     tree_->Branch( "jetAK8_puppi_pt"        , &jetAK8_puppi_pt    	);
+     tree_->Branch( "jetAK8_puppi_eta"       , &jetAK8_puppi_eta	);
+     tree_->Branch( "jetAK8_puppi_mass"      , &jetAK8_puppi_mass	 );
+     tree_->Branch( "jetAK8_puppi_phi"       , &jetAK8_puppi_phi	);
+     tree_->Branch( "jetAK8_puppi_e"	     , &jetAK8_puppi_e	);
+     tree_->Branch( "jetAK8_puppi_pruned_mass"      , &jetAK8_puppi_pruned_mass       );
+     tree_->Branch( "jetAK8_puppi_pruned_massCorr"  , &jetAK8_puppi_pruned_massCorr   );
+     tree_->Branch( "jetAK8_puppi_pruned_jec"	    , &jetAK8_puppi_pruned_jec        );
+     tree_->Branch( "jetAK8_puppi_softdrop_mass"    , &jetAK8_puppi_softdrop_mass     ); 
+     tree_->Branch( "jetAK8_puppi_softdrop_massCorr", &jetAK8_puppi_softdrop_massCorr );
+     tree_->Branch( "jetAK8_puppi_softdrop_jec"     , &jetAK8_puppi_softdrop_jec      );
+     tree_->Branch( "jetAK8_puppi_tau1"	            , &jetAK8_puppi_tau1	      );
+     tree_->Branch( "jetAK8_puppi_tau2"	            , &jetAK8_puppi_tau2      	      );
+     tree_->Branch( "jetAK8_puppi_tau3"	            , &jetAK8_puppi_tau3	      );
+
+      // /*----------------------puppi_softdrop AK8 subjets---------------------------*/
+      tree_->Branch( "jetAK8_subjet_puppi_softdrop_N"            , &jetAK8_subjet_puppi_softdrop_N  	   );
+      tree_->Branch( "jetAK8_subjet_puppi_softdrop_pt"           , &jetAK8_subjet_puppi_softdrop_pt      	   );
+      tree_->Branch( "jetAK8_subjet_puppi_softdrop_eta"          , &jetAK8_subjet_puppi_softdrop_eta     	   );
+      tree_->Branch( "jetAK8_subjet_puppi_softdrop_mass"         , &jetAK8_subjet_puppi_softdrop_mass    	   );
+      tree_->Branch( "jetAK8_subjet_puppi_softdrop_phi"          , &jetAK8_subjet_puppi_softdrop_phi     	   );
+      tree_->Branch( "jetAK8_subjet_puppi_softdrop_e"            , &jetAK8_subjet_puppi_softdrop_e       	   );
+      tree_->Branch( "jetAK8_subjet_puppi_softdrop_charge"       , &jetAK8_subjet_puppi_softdrop_charge        );
+      if ( runFlags["runOnMC"] ){
+        tree_->Branch( "jetAK8_subjet_puppi_softdrop_genParton_pdgID", &jetAK8_subjet_puppi_softdrop_genParton_pdgID );
+        tree_->Branch( "jetAK8_subjet_puppi_softdrop_nbHadrons", &jetAK8_subjet_puppi_softdrop_nbHadrons );
+        tree_->Branch( "jetAK8_subjet_puppi_softdrop_ncHadrons", &jetAK8_subjet_puppi_softdrop_ncHadrons );
+        tree_->Branch( "jetAK8_subjet_puppi_softdrop_partonFlavour", &jetAK8_subjet_puppi_softdrop_partonFlavour );
+        tree_->Branch( "jetAK8_subjet_puppi_softdrop_hadronFlavour", &jetAK8_subjet_puppi_softdrop_hadronFlavour );
+      }
+      tree_->Branch( "jetAK8_subjet_puppi_softdrop_csv"          , &jetAK8_subjet_puppi_softdrop_csv           );
+    }
     	  
     if (runFlags["doPrunedSubjets"]) {
     
@@ -964,6 +982,21 @@ void NtupleBranches::reset( void ){
   jetAK8_subjet_softdrop_partonFlavour.clear();
   jetAK8_subjet_softdrop_hadronFlavour.clear();
   jetAK8_subjet_softdrop_csv.clear();
+
+  /** puppi_softdrop AK8 subjets */
+  jetAK8_subjet_puppi_softdrop_N.clear();
+  jetAK8_subjet_puppi_softdrop_pt.clear();
+  jetAK8_subjet_puppi_softdrop_eta.clear();
+  jetAK8_subjet_puppi_softdrop_mass.clear();
+  jetAK8_subjet_puppi_softdrop_phi.clear();
+  jetAK8_subjet_puppi_softdrop_e.clear();
+  jetAK8_subjet_puppi_softdrop_charge.clear();
+  jetAK8_subjet_puppi_softdrop_genParton_pdgID.clear();
+  jetAK8_subjet_puppi_softdrop_nbHadrons	 .clear();
+  jetAK8_subjet_puppi_softdrop_ncHadrons	.clear();
+  jetAK8_subjet_puppi_softdrop_partonFlavour.clear();
+  jetAK8_subjet_puppi_softdrop_hadronFlavour.clear();
+  jetAK8_subjet_puppi_softdrop_csv.clear();
 
   /** puppi and ATLAS */      
   jetAK8_puppi_pt.clear();

--- a/Ntuplizer/plugins/Ntuplizer.cc
+++ b/Ntuplizer/plugins/Ntuplizer.cc
@@ -90,6 +90,7 @@ Ntuplizer::Ntuplizer(const edm::ParameterSet& iConfig):
   runFlags["doPuppi"] = iConfig.getParameter<bool>("doPuppi");
   runFlags["doHbbTag"] = iConfig.getParameter<bool>("doHbbTag");
   runFlags["doMETSVFIT"] = iConfig.getParameter<bool>("doMETSVFIT");
+  runFlags["doPuppiRecluster"] = iConfig.getParameter<edm::InputTag>("puppijets").label()!="";
 
   std::string jecpath = iConfig.getParameter<std::string>("jecpath");
   

--- a/Ntuplizer/python/ntuplizerOptions_MC_cfi.py
+++ b/Ntuplizer/python/ntuplizerOptions_MC_cfi.py
@@ -3,7 +3,6 @@ import FWCore.ParameterSet.Config as cms
 config = dict()
 
 #--------- general ----------#
-config["FALL15"] = False
 config["SPRING16"] = True
 config["RUNONMC"] = True
 config["USEJSON"] = False
@@ -34,8 +33,8 @@ config["DOMETSVFIT"] = False
 config["ADDAK8GENJETS"] = False #! Add AK8 gen jet collection with pruned and softdrop mass
 config["DOAK8RECLUSTERING"] = False
 config["DOAK8PRUNEDRECLUSTERING"] = False #! To add pruned jet and pruned subjet collection (not in MINIAOD)
-config["DOAK8PUPPIRECLUSTERING"] = True
-config["DOAK10TRIMMEDRECLUSTERING"] = True #ATLAS sequence
+config["DOAK8PUPPI"] = True
+config["DOAK10TRIMMEDRECLUSTERING"] = False #ATLAS sequence
 config["DOHBBTAG"] = False #Higgs-tagger
 
 #--------- MET reclustering ----------#

--- a/Ntuplizer/python/ntuplizerOptions_data_cfi.py
+++ b/Ntuplizer/python/ntuplizerOptions_data_cfi.py
@@ -3,7 +3,6 @@ import FWCore.ParameterSet.Config as cms
 config = dict()
 
 #--------- general ----------#
-config["FALL15"] = False
 config["SPRING16"] = True
 config["RUNONMC"] = False
 config["USEJSON"] = True
@@ -35,8 +34,8 @@ config["DOMETSVFIT"] = False
 config["ADDAK8GENJETS"] = False #! Add AK8 gen jet collection with pruned and softdrop mass
 config["DOAK8RECLUSTERING"] =False
 config["DOAK8PRUNEDRECLUSTERING"] = False #! To add pruned jet and pruned subjet collection (not in MINIAOD)
-config["DOAK8PUPPIRECLUSTERING"] = True
-config["DOAK10TRIMMEDRECLUSTERING"] = True #ATLAS sequence
+config["DOAK8PUPPI"] = True
+config["DOAK10TRIMMEDRECLUSTERING"] = False #ATLAS sequence
 config["DOHBBTAG"] = False #Higgs-tagger
 
 #--------- MET reclustering ----------#


### PR DESCRIPTION
No change if running on MiniAODv1. If running on MiniAODv2, there is no need to recluster PUPPI since it is available in MiniAOD now.
For AK8 jets with pT>200 the result is identical. There is some difference between 170<pt<200, due to a different logic of applying the jet pT cut in MiniAOD and in our ntuplizer.

![compare](https://cloud.githubusercontent.com/assets/4518137/15574873/19f2acf0-2350-11e6-914e-95992005f448.png)

Note that all data is processed in MiniAODv2, thus this affects all data.
