### PR TITLE
Save correct number of gen particles to genParticle_N

### DIFF
--- a/Ntuplizer/plugins/GenParticlesNtuplizer.cc
+++ b/Ntuplizer/plugins/GenParticlesNtuplizer.cc
@@ -27,7 +27,7 @@ GenParticlesNtuplizer::~GenParticlesNtuplizer( void )
     std::vector<int> vMoth;
     int nMoth = 0;
     int nDau  = 0;  
-    nBranches_->genParticle_N = genParticles_->size();
+    //nBranches_->genParticle_N = genParticles_->size(); // the genParticles are filtered below
     for( unsigned p=0; p<genParticles_->size(); ++p ){
       //if( (*genParticles_)[p].status() != 3 ) continue;
       vDau.clear(); vMoth.clear();
@@ -152,6 +152,7 @@ GenParticlesNtuplizer::~GenParticlesNtuplizer( void )
 
     }
 
+    nBranches_->genParticle_N = nBranches_->genParticle_pt.size(); // save number of save genParticles
     
 }
 


### PR DESCRIPTION
Gen particles are filtered before saving, so genParticle_N should be the number of saved gen particles.