### PR TITLE
Include gen weight for the B generic sample

### DIFF
--- a/Ntuplizer/config_generic_opt_skimmed.py
+++ b/Ntuplizer/config_generic_opt_skimmed.py
@@ -50,7 +50,7 @@ options.register( 'runUpToEarlyF',
 
 
 
-options.maxEvents = 2000
+options.maxEvents = 200
 #options.maxEvents = -1
 
 #data file
@@ -97,7 +97,9 @@ else:
 #                              skipEvents=cms.untracked.uint32(23000)
                               ) 
 
-print " process source filenames %s" %(process.source) 
+print " process source filenames %s" %(process.source)
+
+#print " process source filenames ", process.source.fileNames
 ######## Sequence settings ##########
 
 hltFiltersProcessName = 'RECO'
@@ -306,9 +308,17 @@ if config["CORRMETONTHEFLY"]:
      	 'JEC/%s_DATA_L3Absolute_AK4PFchs.txt'%(JECprefix),
          'JEC/%s_DATA_L2L3Residual_AK4PFchs.txt'%(JECprefix)
        ]	
-      			    
+      	
 
-                                                                       
+################# Weights for B generic background #########
+
+IsBkgBSample = False 
+fileName=str(process.source.fileNames) 
+print(fileName)
+if "HbToJPsiMuMu" in fileName:
+   IsBkgBSample = True		    
+print "IsBkgBSample" ,IsBkgBSample
+
 ################## Ntuplizer ###################
 process.ntuplizer = cms.EDAnalyzer("Ntuplizer",
     runOnMC	      = cms.bool(config["RUNONMC"]),
@@ -335,7 +345,8 @@ process.ntuplizer = cms.EDAnalyzer("Ntuplizer",
     dnnfile_old       = cms.string(config['DNNFILE_OLD']),                        
     dnnfile_perPF     = cms.string(config['DNNFILE_PERPF']),                        
     dnnfile_perEVT    = cms.string(config['DNNFILE_PEREVT']),                        
-    dnnfile_perEVT_v2 = cms.string(config['DNNFILE_PEREVT_V2']),                        
+    dnnfile_perEVT_v2 = cms.string(config['DNNFILE_PEREVT_V2']),
+    isBkgBSample = cms.bool(IsBkgBSample),                        
     vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
     beamSpot = cms.InputTag("offlineBeamSpot"),
     taus = cms.InputTag("slimmedTaus"),

--- a/Ntuplizer/config_generic_opt_skimmed_batch.py
+++ b/Ntuplizer/config_generic_opt_skimmed_batch.py
@@ -341,7 +341,13 @@ if config["CORRMETONTHEFLY"]:
          'JEC/%s_DATA_L2L3Residual_AK4PFchs.txt'%(JECprefix)
        ]	
       			    
+################# Weights for B generic background #########
 
+IsBkgBSample = False 
+fileName=str(process.source.fileNames) 
+if "HbToJPsiMuMu" in fileName:
+  IsBkgBSample = True		    
+print "IsBkgBSample" ,IsBkgBSample
                                                                        
 ################## Ntuplizer ###################
 process.ntuplizer = cms.EDAnalyzer("Ntuplizer",
@@ -363,7 +369,8 @@ process.ntuplizer = cms.EDAnalyzer("Ntuplizer",
     fsigcut           = cms.double(config['FSIGCUT']),
     vprobcut          = cms.double(config['VPROBCUT']),
     dnncut            = cms.double(config['DNNCUT']),
-    dnnfile           = cms.string(config['DNNFILE']),                        
+    dnnfile           = cms.string(config['DNNFILE']),  
+    isBkgBSample = cms.bool(IsBkgBSample),                          
     vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
     beamSpot = cms.InputTag("offlineBeamSpot"),
     taus = cms.InputTag("slimmedTaus"),

--- a/Ntuplizer/config_generic_opt_skimmed_crab.py
+++ b/Ntuplizer/config_generic_opt_skimmed_crab.py
@@ -297,8 +297,13 @@ if config["CORRMETONTHEFLY"]:
      	 'JEC/%s_DATA_L3Absolute_AK4PFchs.txt'%(JECprefix),
          'JEC/%s_DATA_L2L3Residual_AK4PFchs.txt'%(JECprefix)
        ]	
+################# Weights for B generic background #########
       			    
-
+IsBkgBSample = False 
+fileName=str(process.source.fileNames) 
+if "HbToJPsiMuMu" in fileName:
+  IsBkgBSample = True		    
+print "IsBkgBSample" ,IsBkgBSample
                                                                        
 ################## Ntuplizer ###################
 process.ntuplizer = cms.EDAnalyzer("Ntuplizer",
@@ -317,7 +322,8 @@ process.ntuplizer = cms.EDAnalyzer("Ntuplizer",
     fsigcut           = cms.double(config['FSIGCUT']),
     vprobcut          = cms.double(config['VPROBCUT']),
     dnncut            = cms.double(config['DNNCUT']),
-    dnnfile           = cms.string(config['DNNFILE']),                        
+    dnnfile           = cms.string(config['DNNFILE']),
+    isBkgBSample = cms.bool(IsBkgBSample),                         
     vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
     beamSpot = cms.InputTag("offlineBeamSpot"),
     taus = cms.InputTag("slimmedTaus"),

--- a/Ntuplizer/interface/GenParticlesNtuplizer.h
+++ b/Ntuplizer/interface/GenParticlesNtuplizer.h
@@ -16,7 +16,7 @@ class GenParticlesNtuplizer : public CandidateNtuplizer {
 
 public:
   GenParticlesNtuplizer( std::vector<edm::EDGetTokenT<reco::GenParticleCollection>> tokens, 
-			 NtupleBranches* nBranches, std::map< std::string, bool >&  runFlags );
+                         NtupleBranches* nBranches, std::map< std::string, bool >&  runFlags, bool isBkgBSample, TH1F* fileweight );
 
   ~GenParticlesNtuplizer( void ); 
 
@@ -24,7 +24,7 @@ public:
 
   void recursiveDaughters(size_t index, int rank, const reco::GenParticleCollection &src, std::vector<size_t> &allIndices, std::vector<int> &pdgs, std::vector<int> &layers, std::vector<float> &ppt, std::vector<float> &peta, std::vector<float> &pphi);
 
-  
+  const reco::Candidate* checkMom(const reco::Candidate * candMom);
 
 private:
    edm::EDGetTokenT<reco::GenParticleCollection> genParticlesToken_;
@@ -33,7 +33,8 @@ private:
    bool verbose_;
 
    helper aux;
-
+   bool isBkgBSample_;
+   TH1F* histGenWeights_ ;
 };
 
 #endif // GenParticlesNtuplizer_H

--- a/Ntuplizer/interface/Ntuplizer.h
+++ b/Ntuplizer/interface/Ntuplizer.h
@@ -43,6 +43,7 @@ public:
   std::map< std::string, double > runValues;
   std::map< std::string, std::string > runStrings;
  
+
 private:
   virtual void beginJob()                                                                   override;
   virtual void analyze(const edm::Event&, const edm::EventSetup&)                           override;
@@ -110,4 +111,7 @@ private:
   edm::EDGetTokenT<bool>                                    HBHENoiseIsoFilterResultToken_;  
   edm::EDGetTokenT<bool>                                    ecalBadCalibFilterUpdateToken_;
 
+  bool                                    isBkgBSample_;
+  TFile  *fileWeights;
+  TH1F  *histGenWeights;
 };

--- a/Ntuplizer/plugins/NtupleBranches.cc
+++ b/Ntuplizer/plugins/NtupleBranches.cc
@@ -46,7 +46,8 @@ void NtupleBranches::branch( std::map< std::string, bool >& runFlags ){
       tree_->Branch( "genParticle_ppt"	     , &genParticle_ppt        );
       tree_->Branch( "genParticle_peta"	     , &genParticle_peta        );
       tree_->Branch( "genParticle_pphi"	     , &genParticle_pphi        );
-	
+      ////Adding weight based on B decay chain for B generic bkg sample
+      tree_->Branch( "genWeightBkgB"             , &genWeightBkgB       );
 	
     } //doGenParticles
       
@@ -1392,7 +1393,8 @@ void NtupleBranches::reset( void ){
   genParticle_nMoth.clear();
   genParticle_nDau.clear();
   genParticle_dau.clear();
-  
+  genWeightBkgB = 0;
+
   //  genParticle_pmother.clear();
   genParticle_pdgs.clear();
   genParticle_layers.clear();


### PR DESCRIPTION
For B generic sample, the name of the input file is assumed to include the string "HbToJPsiMuMu".
If that's the case, the mother of the Jpsi decay is checked and depending on the B hadron type  a weight is taken from the file `root://cms-xrd-global.cern.ch//store/user/fiorendi/p5prime/HBMC/decay_weight.root` and saved in the variable `genWeightBkgB`. 

I tested the code on a signal sample and it seems to pick up the right weight for a Bc decay. But a final test should be made once the final background samples are available.