### PR TITLE
Fixing weights for Bkg B sample

### DIFF
--- a/Ntuplizer/config_generic_opt_skimmed.py
+++ b/Ntuplizer/config_generic_opt_skimmed.py
@@ -34,7 +34,7 @@ isData = False
 print 'isData? ', isData
 
 
-config["ISBKG"] = False
+config["ISBKG"] = True
 
 if isData:
   config["RUNONMC"] = False
@@ -96,6 +96,7 @@ options.maxEvents = 1000
 
 #options.inputFiles = 'file:/scratch/ytakahas/HbToJPsiMuMu/014EC954-4C5E-AD48-BB44-401D779323E3.root'
 
+
 #options.inputFiles = '/store/mc/RunIIAutumn18MiniAOD/OniaAndX_ToMuMu_MuFilter_SoftQCDnonD_TuneCP5_13TeV-pythia8-evtgen/MINIAODSIM/102X_upgrade2018_realistic_v15-v1/00000/01325465-A815-E24E-ABB3-DAB8D4880BDE.root'
 
 if isData:
@@ -103,7 +104,8 @@ if isData:
 
 else:
 
-  options.inputFiles = '/store/mc/RunIISummer19UL18MiniAOD/BcToJPsiTauNu_TuneCP5_13TeV-bcvegpy2-pythia8-evtgen/MINIAODSIM/106X_upgrade2018_realistic_v11_L1v1_ext1-v2/100000/02F13381-1D94-CC43-948A-2EFFB8572949.root'
+  #options.inputFiles = '/store/mc/RunIISummer19UL18MiniAOD/BcToJPsiTauNu_TuneCP5_13TeV-bcvegpy2-pythia8-evtgen/MINIAODSIM/106X_upgrade2018_realistic_v11_L1v1_ext1-v2/100000/02F13381-1D94-CC43-948A-2EFFB8572949.root'
+  options.inputFiles = '/store/mc/RunIISummer20UL18MiniAOD/HbToJPsiMuMu_TuneCP5_13TeV-pythia8-evtgen/MINIAODSIM/106X_upgrade2018_realistic_v11_L1v1-v1/00000/014EC954-4C5E-AD48-BB44-401D779323E3.root'
   
 #options.inputFiles = '/store/data/Run2017F/Charmonium/MINIAOD/09Aug2019_UL2017-v1/20000/00BACB48-9B0F-8F48-A68B-2F08A3E9E681.root'
 #options.inputFiles = '/store/data/Run2016B/Charmonium/MINIAOD/21Feb2020_ver2_UL2016_HIPM-v1/240000/0333D5C7-28C0-7641-994A-ADE29A1EBAAD.root'

--- a/Ntuplizer/interface/GenParticlesNtuplizer.h
+++ b/Ntuplizer/interface/GenParticlesNtuplizer.h
@@ -16,7 +16,8 @@ class GenParticlesNtuplizer : public CandidateNtuplizer {
 
 public:
   GenParticlesNtuplizer( std::vector<edm::EDGetTokenT<reco::GenParticleCollection>> tokens, 
-                         NtupleBranches* nBranches, std::map< std::string, bool >&  runFlags, TH1F* fileweight );
+                         NtupleBranches* nBranches, std::map< std::string, bool >&  runFlags//, TH1F* fileweight
+                         );
 
   ~GenParticlesNtuplizer( void ); 
 
@@ -24,17 +25,17 @@ public:
 
   void recursiveDaughters(size_t index, int rank, const reco::GenParticleCollection &src, std::vector<size_t> &allIndices, std::vector<int> &pdgs, std::vector<int> &layers, std::vector<float> &ppt, std::vector<float> &peta, std::vector<float> &pphi);
 
-  const reco::Candidate* checkMom(const reco::Candidate * candMom);
+  //  const reco::Candidate* checkMom(const reco::Candidate * candMom);
 
 private:
    edm::EDGetTokenT<reco::GenParticleCollection> genParticlesToken_;
    edm::Handle< reco::GenParticleCollection >  genParticles_;
    bool doGenHist_;
    bool verbose_;
-   bool isBkgBSample_;
+   //   bool isBkgBSample_;
 
    helper aux;
-   TH1F* histGenWeights_ ;
+   //TH1F* histGenWeights_ ;
 };
 
 #endif // GenParticlesNtuplizer_H

--- a/Ntuplizer/interface/JpsiTauNtuplizer.h
+++ b/Ntuplizer/interface/JpsiTauNtuplizer.h
@@ -23,14 +23,13 @@ class JpsiTauNtuplizer : public CandidateNtuplizer {
 		    std::map< std::string, bool >& runFlags,
 		    std::map< std::string, double >& runValues,
 		    std::map< std::string, std::string >& runStrings,
-		    NtupleBranches* nBranches );
+                    NtupleBranches* nBranches , TH1F* fileweight );
 
   ~JpsiTauNtuplizer( void );
   
 
   bool fillBranches( edm::Event const & event, const edm::EventSetup& iSetup );
-
-  
+  const reco::Candidate*  checkMom(const reco::Candidate * candMom);
 private:
    edm::EDGetTokenT<pat::MuonCollection>    muonToken_   ;
    edm::EDGetTokenT<reco::VertexCollection> verticeToken_   ;
@@ -63,6 +62,7 @@ private:
    bool isTruth_;
    bool verbose_;
 
+  
    bool flag_fill = false;
 
    float c_dz;
@@ -81,6 +81,8 @@ private:
    std::vector<map<string, double>> FFdict;
 
    helper aux;
+
+
    
    //   tensorflow::MetaGraphDef* graphDef_old;
    tensorflow::MetaGraphDef* graphDef_perPF;
@@ -232,6 +234,10 @@ private:
 
    //   std::vector<double> _FFErr = {1, 1,1,1,1,1,1,1,1,1,1};
 
+   bool isBkgBSample_;
+   TH1F* histGenWeights_ ;
+   float genWeightBkgB_ =1;
+   int motherID_ =0;
 
 
 

--- a/Ntuplizer/interface/NtupleBranches.h
+++ b/Ntuplizer/interface/NtupleBranches.h
@@ -79,7 +79,7 @@ public:
     
   /** genParticles */
   int                             genParticle_N;
-  float genWeightBkgB;
+ 
   std::vector<float>              genParticle_pt       ;
 //  std::vector<float>              genParticle_px       ;
 //  std::vector<float>              genParticle_py       ;
@@ -738,6 +738,8 @@ public:
   int                  JpsiTau_isgenmatched;
   //  int                  JpsiTau_isgen3;
   //  int                  JpsiTau_isgen3matched;
+
+  float genWeightBkgB;
 
   int JpsiTau_nch;
   //  int JpsiTau_nch_after_dnn;

--- a/Ntuplizer/plugins/GenParticlesNtuplizer.cc
+++ b/Ntuplizer/plugins/GenParticlesNtuplizer.cc
@@ -1,14 +1,15 @@
 #include "../interface/GenParticlesNtuplizer.h"
  
 //===================================================================================================================        
-GenParticlesNtuplizer::GenParticlesNtuplizer( std::vector<edm::EDGetTokenT<reco::GenParticleCollection>> tokens, NtupleBranches* nBranches, std::map< std::string, bool >& runFlags, TH1F* histGenWeights ) 
+GenParticlesNtuplizer::GenParticlesNtuplizer( std::vector<edm::EDGetTokenT<reco::GenParticleCollection>> tokens, NtupleBranches* nBranches, std::map< std::string, bool >& runFlags//, TH1F* histGenWeights
+ ) 
 
    : CandidateNtuplizer( nBranches )
    , genParticlesToken_( tokens[0] )
    , doGenHist_( runFlags["doGenHist"]  )
    , verbose_   (runFlags["verbose"])
-   , isBkgBSample_ (runFlags["isBkgBSample"])
-   , histGenWeights_ (histGenWeights)
+   // , isBkgBSample_ (runFlags["isBkgBSample"])
+//    , histGenWeights_ (histGenWeights)
 {
 
 }
@@ -225,34 +226,34 @@ bool GenParticlesNtuplizer::fillBranches( edm::Event const & event, const edm::E
         bool isStatus2( (*genParticles_)[p].status()==2 );
         bool isStatus1( (*genParticles_)[p].status()==1 );
 
-        // Implementation fo the weight for the B chain decay in the generic background B sample
-        if (isBkgBSample_){        
-	  //            int motherID=0;
+      //   // Implementation fo the weight for the B chain decay in the generic background B sample
+      //   if (isBkgBSample_){        
+	  // //            int motherID=0;
             
-            if (abs((*genParticles_)[p].pdgId())==443 and abs((*genParticles_)[p].daughter(0)->pdgId())==13 ){
-	      int motherID = abs((GenParticlesNtuplizer::checkMom(&(*genParticles_)[p]))->pdgId());
-                // std:: cout<< " Jpsi status is "    <<  (*genParticles_)[p].status() << std::endl;
-                // std:: cout<< " Jpsi daugh is "    <<   (*genParticles_)[p].daughter(0)->pdgId() << std::endl;
-		//		std:: cout<< " Jpsi mother is "    << motherID << std::endl;
+      //       if (abs((*genParticles_)[p].pdgId())==443 and abs((*genParticles_)[p].daughter(0)->pdgId())==13 ){
+      //           int motherID = abs((GenParticlesNtuplizer::checkMom(&(*genParticles_)[p]))->pdgId());
+      //           std:: cout<< " Jpsi status is "    <<  (*genParticles_)[p].status() << std::endl;
+      //           std:: cout<< " Jpsi daugh is "    <<   (*genParticles_)[p].daughter(0)->pdgId() << std::endl;
+      //           std:: cout<< " Jpsi mother is "    << motherID << std::endl;
                 
-                std::vector<int> B_hadron = {511,521,531,541,5112,5122,5132,5212,5232};   // at the beginning of the hist there is a bin for the all other possible decays   
+      //           std::vector<int> B_hadron = {511,521,531,541,5112,5122,5132,5212,5232};   // at the beginning of the hist there is a bin for the all other possible decays   
                 
-                std::vector<int>::iterator it = std::find(B_hadron.begin(), B_hadron.end(), motherID);
-                int index;
-                if (it != B_hadron.end()) {
-                    index = std::distance(B_hadron.begin(), it);
-                    //std:: cout<< "index is " << index <<" weight is " << histGenWeights_->GetBinContent(index+2)<< std::endl;
-                    nBranches_->genWeightBkgB = histGenWeights_->GetBinContent(index+2);
-                } else {
-                    nBranches_->genWeightBkgB = histGenWeights_->GetBinContent(1); // in the first bin of the hist there is a generic 'other' for all the b decays not contained in the B_hadron vector;
-                } 
-            }
-        } else { 
-            nBranches_->genWeightBkgB = 1;
-        }
+      //           std::vector<int>::iterator it = std::find(B_hadron.begin(), B_hadron.end(), motherID);
+      //           int index;
+      //           if (it != B_hadron.end()) {
+      //               index = std::distance(B_hadron.begin(), it);
+      //               std:: cout<< "index is " << index <<" weight is " << histGenWeights_->GetBinContent(index+2)<< std::endl;
+      //               nBranches_->genWeightBkgB = histGenWeights_->GetBinContent(index+2);
+      //           } else {
+      //               nBranches_->genWeightBkgB = histGenWeights_->GetBinContent(1); // in the first bin of the hist there is a generic 'other' for all the b decays not contained in the B_hadron vector;
+      //           } 
+      //       }
+      //   } else { 
+      //       nBranches_->genWeightBkgB = 1;
+      //   }
         
     
-        if(!isLepton && !isQuark && !isPhoton && !isGluon && !isWZH && !isHeavyMeson && !isHeavyBaryon && !isBSM && !isDirectPromptTauDecayProduct && !fromHardProcessFinalState && !isDirectHardProcessTauDecayProductFinalState && !isB && !isStatus2 && !isStatus1) continue;
+         if(!isLepton && !isQuark && !isPhoton && !isGluon && !isWZH && !isHeavyMeson && !isHeavyBaryon && !isBSM && !isDirectPromptTauDecayProduct && !fromHardProcessFinalState && !isDirectHardProcessTauDecayProductFinalState && !isB && !isStatus2 && !isStatus1) continue;
       
         //      nBranches_->genParticle_px    .push_back((*genParticles_)[p].px()     );
         //      nBranches_->genParticle_py    .push_back((*genParticles_)[p].py()     );
@@ -376,27 +377,4 @@ bool GenParticlesNtuplizer::fillBranches( edm::Event const & event, const edm::E
     //if     nBranches_->genWeightBkgB = 1;    
 
     return true;
-}
-
-
-const reco::Candidate*  GenParticlesNtuplizer::checkMom(const reco::Candidate * candMom){
-    int diquarks[] = { 1103,2101,2103,2203,3101,3103,3201,3203,3303,4101,4103,4201,4203,4301,4303,4403,5101,5103,5201,5203,5301,5303,5401, 5403,5503};
-    if (candMom == nullptr) return nullptr;
-    
-    if (candMom->mother(0) == nullptr) {
-        return candMom;
-    }  
-    int * p = std::find (diquarks, diquarks+25, candMom->mother(0)->pdgId());
-    if (abs(candMom->mother(0)->pdgId()) < 8  ||    \
-        abs(candMom->mother(0)->pdgId())== 21 ||    \
-        abs(candMom->mother(0)->pdgId())== 2212 ||  \
-        (p != (diquarks+25))
-      ){ 
-        
-    return candMom;
-    }
-    else {
-        candMom = checkMom(candMom->mother(0));
-    return candMom;
-    }  
 }

--- a/Ntuplizer/plugins/NtupleBranches.cc
+++ b/Ntuplizer/plugins/NtupleBranches.cc
@@ -46,8 +46,8 @@ void NtupleBranches::branch( std::map< std::string, bool >& runFlags ){
       tree_->Branch( "genParticle_ppt"	     , &genParticle_ppt        );
       tree_->Branch( "genParticle_peta"	     , &genParticle_peta        );
       tree_->Branch( "genParticle_pphi"	     , &genParticle_pphi        );
-      ////Adding weight based on B decay chain for B generic bkg sample
-      tree_->Branch( "genWeightBkgB"             , &genWeightBkgB       );
+      // ////Adding weight based on B decay chain for B generic bkg sample
+      // tree_->Branch( "genWeightBkgB"             , &genWeightBkgB       );
 	
     } //doGenParticles
       
@@ -695,6 +695,8 @@ void NtupleBranches::branch( std::map< std::string, bool >& runFlags ){
 
 
   if (runFlags["runOnMC"] ){
+      ////Adding weight based on B decay chain for B generic bkg sample                                                                                                                                                                            
+      tree_->Branch( "genWeightBkgB"             , &genWeightBkgB       );
     tree_->Branch("JpsiTau_genPV_vx", &JpsiTau_genPV_vx );
     tree_->Branch("JpsiTau_genPV_vy", &JpsiTau_genPV_vy );
     tree_->Branch("JpsiTau_genPV_vz", &JpsiTau_genPV_vz );

--- a/Ntuplizer/plugins/Ntuplizer.cc
+++ b/Ntuplizer/plugins/Ntuplizer.cc
@@ -126,6 +126,7 @@ Ntuplizer::Ntuplizer(const edm::ParameterSet& iConfig):
   /* Histogram for cutflow */
 
   nBranches_->cutflow_perevt = fs->make<TH1F>("cutflow_perevt", "Per Event Ntuplizer Cutflow", 15, 0, 15);
+  //nBranches_->hist_BkgB_weight = fs->make<TH2F>("hist_BkgB_weight", "Bkg B sample decay chain and weight", 11, 0, 11, 100,0 ,100);
 
   nBranches_->nmuon = fs->make<TH1F>("nmuon", "number of muon", 10, 0, 10);
 
@@ -214,6 +215,18 @@ Ntuplizer::Ntuplizer(const edm::ParameterSet& iConfig):
 						     runFlags    );
   }
 
+  if ( runFlags["runOnMC"] ){
+      if (runFlags["isBkgBSample"] ){
+          
+          std::string bweightfilepath = edm::FileInPath("EXOVVNtuplizerRunII/Ntuplizer/" + runStrings["bweightfile"]).fullPath();
+          //  fileWeights = new TFile("root://eoscms.cern.ch//eos/cms/store/user/fiorendi/p5prime/HBMC/decay_weight.root", "READ");                                                                                                                           
+          
+          std::cout << "b weight file = "<< bweightfilepath << std::endl;
+          fileWeights = new TFile((TString)bweightfilepath);
+          histGenWeights=(TH1F*)fileWeights->Get("weight");
+          std::cout << "weight hist first bin is : "<<  histGenWeights->GetBinContent(1)<<std::endl ;
+      }
+  }
 
   if (runFlags["doJpsiMu"]) {
     std::cout<<"\n\n --->GETTING INSIDE doJpsiMu<---\n\n"<<std::endl;
@@ -239,7 +252,8 @@ Ntuplizer::Ntuplizer(const edm::ParameterSet& iConfig):
 						   runFlags,
 						   runValues,
 						   runStrings,
-						   nBranches_ );
+                           nBranches_ , 
+                           histGenWeights);
   }
 
 //  if (runFlags["doBsTauTau"]) {
@@ -306,22 +320,13 @@ Ntuplizer::Ntuplizer(const edm::ParameterSet& iConfig):
  
   /*=======================================================================================*/    
   if ( runFlags["runOnMC"] ){
-      if (runFlags["isBkgBSample"] ){                                                                                  
-
-	std::string bweightfilepath = edm::FileInPath("EXOVVNtuplizerRunII/Ntuplizer/" + runStrings["bweightfile"]).fullPath();                                                                                     
-	//	fileWeights = new TFile("root://eoscms.cern.ch//eos/cms/store/user/fiorendi/p5prime/HBMC/decay_weight.root", "READ");                                                                   
-
-	std::cout << "b weight file = "<< bweightfilepath << std::endl;
-	fileWeights = new TFile((TString)bweightfilepath);
-	histGenWeights=(TH1F*)fileWeights->Get("weight");                                                                                                                                        
-	std::cout << "weight hist first bin is : "<<  histGenWeights->GetBinContent(1)<<std::endl ;                                                                                            
-      }
      
     if (runFlags["doGenParticles"]) {
       std::vector<edm::EDGetTokenT<reco::GenParticleCollection>> genpTokens;
       genpTokens.push_back( genparticleToken_ );
 
-      nTuplizers_["genParticles"] = new GenParticlesNtuplizer( genpTokens, nBranches_, runFlags, histGenWeights );
+      nTuplizers_["genParticles"] = new GenParticlesNtuplizer( genpTokens, nBranches_, runFlags//, histGenWeights 
+                                                               );
     }
 
     if (runFlags["doPileUp"]) {


### PR DESCRIPTION
Move the code for the re-weighting in JpsiTauNtuplizer. 
Fixed the decay chain with intermediate particles.
Introduced the weight for the B decay chain in the normalization of the sample (the first bin of the cutflow histogram is filled with the weight)
IMPORTANT: the flag to determine if it is the bkg or the signal sample should be correctly set when the samples are produced: for the signal the weight should be 1 for the generic background it should be 0.  To avoid mistakes by end, I'd suggest to implement back the check on the name of the sample; but it is up to you, Yuta :)

